### PR TITLE
Algebra learning framework; added algorithms for SFA and Equality; un…

### DIFF
--- a/SVPABenchmark/src/benchmark/algebralearning/RELearning.java
+++ b/SVPABenchmark/src/benchmark/algebralearning/RELearning.java
@@ -1,0 +1,75 @@
+package benchmark.algebralearning;
+
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.equality.EqualityAlgebraLearnerFactory;
+import algebralearning.sfa.SFAAlgebraLearner;
+import algebralearning.sfa.SFAEquivalenceOracle;
+import algebralearning.sfa.SFAMembershipOracle;
+import automata.sfa.SFA;
+import benchmark.SFAprovider;
+import theory.characters.CharPred;
+import theory.intervals.UnaryCharIntervalSolver;
+
+/**
+ * This class implements the first experiment (section 6.1) from the paper 
+ * "The Learnability of Symbolic Automata" by George Argyros and Loris D'Antoni. 
+ * 
+ * @author George Argyros
+ *
+ */
+public class RELearning {
+
+	static String[] reBenchmarks = {
+			"\\<.*(script|xss).*?\\>",
+			"\\<.*(applet|b(ase|gsound|link)|embed)[^\\>]*\\>",
+			"(\\<[^\\<\\>]+\\>\\<[^<]+\\>\\<\\/[^\\<\\>]+\\>)",
+			"(<meta[/+\\t\\n ].*?http-equiv[/+\\t\\n ])",
+			"(<\\?import[/+\\t\\n ].*?implementation[/+\\t\\n ])",
+			"(alter\\s*\\w+.*character\\s+set\\s+\\w+)|(\\\";\\s*waitfor\\s+time\\s+\\\")|(\\\"\\;.*:\\s*goto)",
+			"(and)\\s+(\\d{1,10}|\\'[^\\=]{1,10}\\')\\s*?[\\=]|(and)\\s+(\\d{1,10}|\\'[^\\=]{1,10}\\')\\s*?[\\<\\>]|and\\s?(\\d{1,10}|[\\'\\\"][^\\=]{1,10}[\\'\\\"])\\s?[\\=\\<\\>]+|(and)\\s+(\\d{1,10}|\\'[^\\=]{1,10}\\')",
+			"([^a-zA-Z]\\s+as\\s*[\\\"a-z0-9A-Z]+\\s*from)|([^a-zA-Z]+\\s*(union|select|create|rename|truncate|load|alter|delete|update|insert|desc))|((select|create|rename|truncate|load|alter|delete|update|insert|desc)\\s+((group_)concat|char|load\\_file)\\s?\\(?)",
+			"(\\,\\s*(alert|showmodaldialog|eval)\\s*\\,)|(\\s*eval\\s*[^ ])|([^:\\s\\w\\,.\\/?+-]\\s*)?(\\<\\![a-z\\/\\_@])(\\s*return\\s*)?((document\\s*\\.)?(.+\\/)?(alert|eval|msgbox|showmod(al|eless)dialog|showhelp|prompt|write(ln)?|confirm|dialog|open))\\s*([^.a-z\\s\\-]|(\\s*[^\\s\\w\\,.@\\/+-]))|(java[ \\/]*\\.[ \\/]*lang)|(\\w\\s*\\=\\s*new\\s+\\w+)|(&\\s*\\w+\\s*\\)[^\\,])|(\\+[^a-zA-Z]*new\\s+\\w+[^a-zA-Z]*\\+)|(document\\.\\w)",
+			"(union\\s*(all|distinct|[(\\!\\@]*)\\s*[([]*\\s*select)|(\\w+\\s+like\\s+\\\")|(like\\s*\\\"\\\\%)|(\\\"\\s*like\\W*[\\\"0-9])|(\\\"\\s*(n?and|x?or|not[ ]|\\|\\||\\\\&\\\\&)\\s+[ a-z0-9A-Z]+\\=\\s*\\w+\\s*having)|(\\\"\\s*\\*\\s*\\w+\\W+\\\")|(\\\"\\s*[^?a-z0-9A-Z \\=.,;)(]+\\s*[(\\@\\\"]*\\s*\\w+\\W+\\w)|(select\\s*[\\[\\]\\(\\)\\s\\w\\.,\\\"-]+from)|(find_in_set\\s*\\()",
+			"(\\w|\\-)+\\@((\\w|\\-)+\\.)+(\\w|\\-)+",
+			"\\$?(\\d{1,3}\\,?(\\d{3}\\,?)*\\d{3}(\\.\\d{0,2})?|\\d{1,3}(\\.\\d{0,2})?|\\.\\d{1,2}?)",
+			"([A-Z]{2}|[a-z]{2}[ ]\\d{2}[ ][A-Z]{1,2}|[a-z]{1,2}[ ]\\d{1,4})?([A-Z]{3}|[a-z]{3}[ ]\\d{1,4})?",
+			"[A-Za-z0-9](([ \\.\\-]?[a-zA-Z0-9]+)*)\\@([A-Za-z0-9]+)(([\\.\\-]?[a-zA-Z0-9]+)*)\\.[ ]([A-Za-z][A-Za-z]+)",
+			"[\\+\\-]?([0-9]*\\.?[0-9]+|[0-9]+\\.?[0-9]*)([eE][\\+\\-]?[0-9]+)?"
+	};		
+		
+	public Integer[] learnREBenchmark(Integer index) throws TimeoutException {
+		Integer[] results = new Integer[8];
+		
+		if (index < 0 || index >= reBenchmarks.length) {
+			return null; 
+		}
+		UnaryCharIntervalSolver solver = new UnaryCharIntervalSolver();
+		SFAprovider provider = new SFAprovider(reBenchmarks[index], solver);			
+		SFA<CharPred, Character> model, sfa = provider.getSFA();
+    	    		
+		SFAMembershipOracle <CharPred, Character> memb = new SFAMembershipOracle<>(sfa, solver);  
+		SFAEquivalenceOracle <CharPred, Character> equiv = new SFAEquivalenceOracle<>(sfa, solver); 
+		EqualityAlgebraLearnerFactory <CharPred, Character> eqFactory = new EqualityAlgebraLearnerFactory <>(solver);
+		SFAAlgebraLearner <CharPred, Character> learner = new SFAAlgebraLearner<>(memb, solver, eqFactory);
+		model = learner.getModelFinal(equiv);
+		// The results are saved in the order that they are presented in the paper.
+		results[0] = model.stateCount();
+		results[1] = model.getTransitionCount();
+		results[2] = memb.getDistinctQueries();
+		results[3] = equiv.getDistinctCeNum();
+		results[4] = equiv.getCachedCeNum();
+		results[5] = learner.getNumCEGuardUpdates();
+		results[6] = learner.getNumDetCE();
+		results[7] = learner.getNumCompCE();
+  		return results;
+	}
+	
+	public Integer[][] learnAllBenchmarks() throws TimeoutException {
+		Integer[][] results = new Integer[reBenchmarks.length][8];
+	    for (int i = 0; i < reBenchmarks.length; i ++) {
+	    	results[i] = learnREBenchmark(i);	    	
+	    }
+	    return results;
+	}
+}

--- a/SVPAlib/src/algebralearning/AlgebraLearner.java
+++ b/SVPAlib/src/algebralearning/AlgebraLearner.java
@@ -1,0 +1,28 @@
+/**
+ * Abstract class for algebra learning algorithms.
+ * 
+ * @author George Argyros
+ */
+package algebralearning;
+
+
+import org.sat4j.specs.TimeoutException;
+import algebralearning.oracles.EquivalenceOracle;
+/**	
+ * Abstract class for implementing learning algorithms for different boolean algebras.
+ *
+ * @param <P> The type of predicates in the boolean algebra.
+ * @param <D> The domain of the underlying boolean algebra. 
+ */
+public abstract class AlgebraLearner <P, D> {
+	
+	/* Return an initial model */
+    public abstract P getModel() throws TimeoutException;
+
+    /* Update the previous model given a counterexample */
+    public abstract P updateModel(D counterexample) throws TimeoutException;
+    
+    /* Learn iteratively a model using the provided equivalence oracle */
+    public abstract P getModelFinal(EquivalenceOracle <P, D> equiv) throws TimeoutException;
+
+}

--- a/SVPAlib/src/algebralearning/AlgebraLearnerFactory.java
+++ b/SVPAlib/src/algebralearning/AlgebraLearnerFactory.java
@@ -1,0 +1,9 @@
+package algebralearning;
+
+import algebralearning.oracles.MembershipOracle;
+
+public abstract class AlgebraLearnerFactory <P,D> {
+
+	public abstract AlgebraLearner <P,D> getBALearner(MembershipOracle <D> m);
+	
+}

--- a/SVPAlib/src/algebralearning/equality/EqualityAlgebraLearner.java
+++ b/SVPAlib/src/algebralearning/equality/EqualityAlgebraLearner.java
@@ -1,0 +1,117 @@
+/**
+ * Learning algorithm for disjunctions (equality algebra)
+ *
+ * @author George Argyros
+ */
+package algebralearning.equality;
+
+import java.util.HashSet;
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.AlgebraLearner;
+import algebralearning.oracles.*;
+import theory.BooleanAlgebra;
+
+/**
+ * For details see the paper and the comments below.
+ * 
+ * @param <P> The type of predicates in the equality algebra
+ * @param <D> The domain of the algebra 
+ */
+public class EqualityAlgebraLearner <P,D> extends AlgebraLearner <P,D> {
+	
+	private BooleanAlgebra <P,D> ba;
+	private HashSet <D> posExamples;
+	private HashSet <D> negExamples;
+	private MembershipOracle <D>memb;
+	
+
+	public EqualityAlgebraLearner(MembershipOracle <D> m, BooleanAlgebra <P,D> b) {
+		ba = b;
+		memb = m;
+		posExamples = new HashSet <>();
+		negExamples = new HashSet <>();
+	}
+	
+	private P generatePositiveModel() throws TimeoutException {
+		P model = ba.False();
+		if (negExamples.size() == 0) {
+			return ba.True();
+		}		
+		for (D e : posExamples) {
+			model = ba.MkOr(ba.MkAtom(e), model);
+		}
+		return model;
+	}
+	
+	private P generateNegativeModel() throws TimeoutException {
+		P model = ba.False();
+		for (D e : negExamples) {
+			model = ba.MkOr(ba.MkAtom(e), model);
+		}
+		return ba.MkNot(model);		
+	}
+	
+	/**
+	 * The algorithm will either generate a disjunction of the form ~(x1 v x2 v ... v xn)
+	 * if the number of positive examples are more than the negatives or a disjunction of 
+	 * the form (x1 v x2 v ... v xn) if the negative samples are more than the positive.
+	 * It can be shown that this method will always converge with at most 2k counterexamples where
+	 * k is the size of the target disjunction.
+	 * 
+	 * @return the model produced based on the given samples in posExamples and negExamples
+	 * @throws TimeoutException
+	 */
+	private P generateModel( ) throws TimeoutException {
+		if (posExamples.size() == 0) {
+			return ba.False();
+		} 
+		if (negExamples.size() == 0) {
+			return ba.True();
+		}
+		if (posExamples.size() >= negExamples.size()) {
+			return generateNegativeModel();
+		} 		
+		return generatePositiveModel();		
+	}
+	
+	/**
+	 * Updates the set of positive or negative samples with a given counterexample
+	 * 
+	 * @param atom the counterexample provided
+	 * @throws TimeoutException
+	 */
+	private void updateExampleLists(D atom) throws TimeoutException {		
+		if (memb.query(atom)) {
+			posExamples.add(atom);
+		} else {
+			negExamples.add(atom);			
+		}
+		return;
+	}
+	
+	/**** PUBLIC METHODS ******/
+		
+	
+	public P getModel() throws TimeoutException {		
+		return generateModel();
+	}
+		
+	public P updateModel(D ce) throws TimeoutException {		
+		if (ba.HasModel(generateModel(), ce) == memb.query(ce)) {
+			throw new AssertionError("Provided counterexample is not a counterexample");
+		}		
+		updateExampleLists(ce);
+		return generateModel();		
+	}
+
+	public P getModelFinal(EquivalenceOracle <P,D> equiv) throws TimeoutException {		
+		D ce;
+		P model = getModel();
+		while ((ce = equiv.getCounterexample(model)) != null) {
+			model = updateModel(ce);
+		}
+		return model;
+	}
+
+}

--- a/SVPAlib/src/algebralearning/equality/EqualityAlgebraLearnerFactory.java
+++ b/SVPAlib/src/algebralearning/equality/EqualityAlgebraLearnerFactory.java
@@ -1,0 +1,20 @@
+package algebralearning.equality;
+
+import algebralearning.AlgebraLearner;
+import algebralearning.AlgebraLearnerFactory;
+import algebralearning.oracles.MembershipOracle;
+import theory.BooleanAlgebra;
+
+public class EqualityAlgebraLearnerFactory <P,D> extends AlgebraLearnerFactory <P,D> {
+
+	private BooleanAlgebra <P,D> ba;
+	
+	public EqualityAlgebraLearnerFactory(BooleanAlgebra <P,D> b) {
+		ba = b;
+	}
+		
+	public AlgebraLearner <P,D> getBALearner(MembershipOracle <D> m) {
+		return new EqualityAlgebraLearner <P,D> (m, ba);
+	}
+
+}

--- a/SVPAlib/src/algebralearning/equality/EqualityEquivalenceOracle.java
+++ b/SVPAlib/src/algebralearning/equality/EqualityEquivalenceOracle.java
@@ -1,0 +1,34 @@
+package algebralearning.equality;
+
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.oracles.EquivalenceOracle;
+import theory.BooleanAlgebra;
+
+public class EqualityEquivalenceOracle <P, D> extends EquivalenceOracle <P,D> {
+
+	BooleanAlgebra <P,D> ba;
+	P target;
+	
+	public EqualityEquivalenceOracle(P trg, BooleanAlgebra <P,D> b) {
+		target = trg;
+		ba = b;
+	}
+	
+	@Override
+	public D getCounterexample(P model) throws TimeoutException {
+		
+		if (ba.AreEquivalent(target, model)) {
+			return null;
+		}
+		// Negate the model and intersect 
+		P negInt = ba.MkAnd(ba.MkNot(model), target);
+		if (ba.IsSatisfiable(negInt)) {
+			return ba.generateWitness(negInt);
+		}
+		// Negate the target and intersect
+		negInt = ba.MkAnd(model, ba.MkNot(target));		
+		return ba.generateWitness(negInt);				
+	}
+
+}

--- a/SVPAlib/src/algebralearning/equality/EqualityMembershipOracle.java
+++ b/SVPAlib/src/algebralearning/equality/EqualityMembershipOracle.java
@@ -1,0 +1,22 @@
+package algebralearning.equality;
+
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.oracles.MembershipOracle;
+import theory.BooleanAlgebra;
+
+public class EqualityMembershipOracle <P, D> extends MembershipOracle <D> {
+
+	private P target;
+	private BooleanAlgebra <P,D>ba;
+	
+	public EqualityMembershipOracle(P trg, BooleanAlgebra <P,D> b) {
+		target = trg;
+		ba = b;
+	}
+	
+	public boolean query(D input) throws TimeoutException {
+		return ba.HasModel(target, input); 
+	}
+	
+}

--- a/SVPAlib/src/algebralearning/oracles/EquivalenceOracle.java
+++ b/SVPAlib/src/algebralearning/oracles/EquivalenceOracle.java
@@ -1,0 +1,19 @@
+/**
+ * Equivalence oracle abstract class implementation
+ * @author George Argyros
+ */
+package algebralearning.oracles;
+
+import org.sat4j.specs.TimeoutException;
+
+public abstract class EquivalenceOracle <P,D> {
+
+	/**
+	 * Return a counterexample between the model and the target
+	 * or null if the two models are equivalent.
+	 * 
+	 * @param model The model to compare the target function against
+	 * @return A counterexample of type D or null if the two models are equivalent
+	 */
+    public abstract D getCounterexample(P model) throws TimeoutException;
+}

--- a/SVPAlib/src/algebralearning/oracles/MembershipOracle.java
+++ b/SVPAlib/src/algebralearning/oracles/MembershipOracle.java
@@ -1,0 +1,26 @@
+/**
+ * Membership oracle abstract class implementation
+ * @author George Argyros
+ */
+package algebralearning.oracles;
+
+
+
+import org.sat4j.specs.TimeoutException;
+
+/**
+ * Membership oracle class used by BooleanAlgebraLearner instances
+ * 
+ * @param <D> Domain of the underlying Boolean algebra
+ */
+public abstract class MembershipOracle <D> {
+	
+	/** 
+	 * Return the result of a running on the input parameter to the target function. 
+	 * 
+	 * @param input The input to the membership query.
+	 * @return true/false depending on the value of the target function on the provided input.
+	 */
+	abstract public boolean query(D input) throws TimeoutException;
+	
+}

--- a/SVPAlib/src/algebralearning/sfa/DiscriminationTree.java
+++ b/SVPAlib/src/algebralearning/sfa/DiscriminationTree.java
@@ -1,0 +1,222 @@
+/**
+ * Implementation of the discrimination (or classification) tree
+ * 
+ * @author George Argyros
+ */
+
+package algebralearning.sfa;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.oracles.MembershipOracle;
+
+
+class TreeNode <D> {
+
+    TreeNode <D> trueChild;
+    TreeNode <D> falseChild;
+    TreeNode <D> parent;
+    List <D> label;
+    Integer height;
+
+	public TreeNode(List <D> l, TreeNode <D> p, TreeNode <D> t,
+					TreeNode <D> f) {
+
+		label = new ArrayList <D>(l);
+        trueChild = t;
+        falseChild = f;
+		parent = p;
+		height = 1;
+    }
+    
+    public void setTrueChild(TreeNode <D> c) {
+        trueChild = c;
+    }
+
+    public void setFalseChild(TreeNode <D> c) {
+        falseChild = c;
+    }
+
+    public void setParent(TreeNode <D> p) {
+        parent = p;
+    }
+
+    public void setLabel(List <D> l) {
+        label = new ArrayList <D>(l);
+    }
+    
+    public boolean isLeaf() {
+        return (trueChild == null && falseChild == null);
+    }
+
+    public TreeNode <D> getTrueChild() {
+        return trueChild;
+    }
+
+    public TreeNode <D> getFalseChild() {
+        return falseChild;
+    }
+
+    public TreeNode <D> getParent() {
+        return parent;
+    }
+
+	public List <D> getLabel() {
+		return label;
+    }
+}
+
+
+public class DiscriminationTree <D> {
+
+    
+    // Root of the tree 
+    private TreeNode <D> root;
+    // Nodes of the tree 
+    private HashSet <List <D>> innerNodes;
+    // Leafs 
+    private List <List <D>> leafs;
+    // Membership oracle to perform queries 
+    MembershipOracle <List<D>> membOracle;
+    // Map to locate leafs for replacement/addition 
+    private Map <List<D>, TreeNode<D>> leafMap;
+    private Boolean isMissingLeafFixed;
+
+
+    public DiscriminationTree(MembershipOracle <List<D>> m) throws TimeoutException {
+        List <D>emptyList = new ArrayList <D>();
+        TreeNode <D> firstLeaf;
+
+        // Initialize basic data structures 
+        innerNodes = new HashSet <List <D>>();
+        leafs = new LinkedList <List <D>>();
+        leafMap = new HashMap <List<D>, TreeNode<D>>();
+		isMissingLeafFixed = false;
+
+        // Initialize the tree with two nodes labelled with the empty sequence */
+        root = new TreeNode <D>(emptyList, null, null, null);
+        firstLeaf = new TreeNode <D>(emptyList, root, null, null);
+        if (m.query(emptyList)) {
+            // empty sequence is a trueChild
+            root.setTrueChild(firstLeaf);
+        } else {
+            // empty sequence is a falseChild
+            root.setFalseChild(firstLeaf);
+        }
+        innerNodes.add(emptyList);
+        leafs.add(emptyList);
+        leafMap.put(emptyList, firstLeaf);
+        membOracle = m;
+    }
+    
+    
+    public List <List<D>> getLeafs() {
+    		return leafs;
+    }
+    
+    
+    /*************** Public methods ***************/
+
+    public List <D> sift(List <D> word) throws TimeoutException {
+    	/*
+    	 * This method implements the sift algorithm as described in the
+    	 * paper. The method will return the leaf for the given input word
+    	 * or, if the corresponding leaf is the missing leaf from the root
+    	 * node of tree, null will be returned.
+    	 * 
+    	 */
+        TreeNode <D> curNode = root;
+        List <D> q;
+        while (!curNode.isLeaf()) {
+			q = new ArrayList <D>(word);
+            q.addAll(curNode.getLabel());
+            if (membOracle.query(q)) {
+                curNode = curNode.getTrueChild();
+            } else {
+                curNode = curNode.getFalseChild();
+            }
+            if (curNode == null) {
+                // Signals the caller to call fixMissingAccessSequence in order
+                // to replace the missing leaf.
+                return null;
+            }
+        }
+        return curNode.getLabel();
+    }
+
+    public void fixMissingAccessSequence(List <D> word) throws TimeoutException {
+    	/*
+    	 * If the sift operation returns null, the caller function can call this method
+    	 * in order to add the missing leaf in the tree. Since there can be only one missing
+    	 * leaf there is no need to specify a location parameter.
+    	 */
+
+        TreeNode <D> newChild = new TreeNode <D>(word, root, null, null);
+        leafs.add(word);
+        if (membOracle.query(word)) {
+            root.setTrueChild(newChild);
+        } else {        	
+            root.setFalseChild(newChild);
+        }
+        leafMap.put(word, newChild);
+        isMissingLeafFixed = true;
+        return;
+    }
+
+    public void splitLeaf(List <D> leafLabel, List <D> newDist,
+                          List <D> newLeaf) throws TimeoutException {
+        TreeNode <D> newLeafNode = new TreeNode <D>(newLeaf, null, null, null);
+        TreeNode <D> newDistNode = new TreeNode <D>(newDist, null, null, null);
+        TreeNode <D> oldLeafNode = leafMap.get(leafLabel);
+        TreeNode <D> oldLeafParent = oldLeafNode.getParent();
+        List <D> q = new ArrayList <D>(newLeaf);
+
+        if (leafs.contains(newLeaf)) {
+        		throw new AssertionError("Attempting to insert existing access string");
+        }
+        
+        // Update internal bookkeeping 
+        innerNodes.add(newDist);
+        leafs.add(newLeaf);
+        leafMap.put(newLeaf, newLeafNode);
+
+        // Fix the properties of each node 
+        oldLeafNode.setParent(newDistNode);
+        newLeafNode.setParent(newDistNode);
+        newDistNode.setParent(oldLeafParent);
+        q.addAll(newDist);
+        if (membOracle.query(q)) {
+            newDistNode.setTrueChild(newLeafNode);
+            newDistNode.setFalseChild(oldLeafNode);
+        } else {
+            newDistNode.setTrueChild(oldLeafNode);
+            newDistNode.setFalseChild(newLeafNode);
+        }
+        // Finally attach to the tree 
+        if (oldLeafParent.getTrueChild() == oldLeafNode) {
+            // oldLeafNode was the trueChild of his parent
+            oldLeafParent.setTrueChild(newDistNode);
+        } else {
+            // Otherwise it was the falseChild
+            oldLeafParent.setFalseChild(newDistNode);
+        }
+        return;
+    }
+    
+        
+    
+    public boolean isTreeComplete() {
+    		return isMissingLeafFixed;
+    }
+    
+    
+    
+    
+}

--- a/SVPAlib/src/algebralearning/sfa/SFAAlgebraLearner.java
+++ b/SVPAlib/src/algebralearning/sfa/SFAAlgebraLearner.java
@@ -1,0 +1,570 @@
+/**
+ * MAT* (SFA learning algorithm) implementation.
+ *  More details about the algorithm can be found in the paper 
+ *  	"The Learnability of Symbolic Automata" by George Argyros and Loris D'Antoni, CAV 2018. 
+ *  
+ * @author George Argyros
+ */
+
+
+package algebralearning.sfa;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Hashtable;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.AlgebraLearner;
+import algebralearning.AlgebraLearnerFactory;
+import algebralearning.oracles.EquivalenceOracle;
+import algebralearning.oracles.MembershipOracle;
+import automata.sfa.SFA;
+import automata.sfa.SFAInputMove;
+import automata.sfa.SFAMove;
+import theory.BooleanAlgebra;
+import utilities.Pair;
+
+/**
+ * The MAT* algorithm relies in underlying boolean algebra learning algorithms in order to infer the 
+ * predicates of the target SFA. This class provides an interface in order to allow the implementation
+ * of a membership oracle for the underlying predicate learners. 
+ *
+ * @param <D> The domain of the boolean algebra of the target SFA.
+ */
+class BALearnerSimulatedMembershipOracle <D> extends MembershipOracle <D> {
+	
+	private DiscriminationTree <D> tree;
+	private List<D> src;
+	private List<D> target;
+	private List<D> missingLeaf;
+	private boolean foundMissingLeaf;
+	
+	public BALearnerSimulatedMembershipOracle(DiscriminationTree <D>t, List <D> s, List<D> trg) {
+		tree = t;
+		src = new ArrayList <D>(s);
+		target = new ArrayList <D>(trg);
+		foundMissingLeaf = false;
+		missingLeaf = null;		
+	}
+	
+	public boolean query(D symbol) throws TimeoutException {
+		List <D> total = new ArrayList <D>(src);
+		List <D> leaf;
+		total.add(symbol);
+		
+		leaf = tree.sift(total);		
+		if (leaf == null) { 
+			tree.fixMissingAccessSequence(total);
+			foundMissingLeaf = true;
+			missingLeaf = total;
+			return false;
+		}		
+		if (leaf.equals(target)) {
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * The discrimination tree when initialized will have only one child from it's root node. When we
+	 * discover a string accessing the other leaf we save it and set the foundMissingLeaf to true. See
+	 * the paper for more details.
+	 * 
+	 * @return whether the missing leaf was found during the execution of any membership query.
+	 */
+	public boolean foundMissingLeaf() { 
+		
+		return foundMissingLeaf;
+	}
+	
+	/**
+	 * See also the foundMissingLeaf() documentation.
+	 * 
+	 * @return an input accessing the missing leaf in the discrimination tree.
+	 */
+	public List <D> getMissingLeaf() {
+		
+		if (!foundMissingLeaf) {
+			throw new AssertionError("getMissingLeaf invalid call");
+		}		
+		return missingLeaf; 
+	}
+}
+
+
+public class SFAAlgebraLearner <P,D> extends AlgebraLearner <SFA <P,D>, List <D>> {
+
+    private DiscriminationTree <D> tree;
+    private MembershipOracle <List <D>> membOracle;
+    private HashMap <Pair<Integer,Integer>, AlgebraLearner <P,D>> algebraLearners;
+    private HashMap <Pair<Integer, Integer>, P> modelGuards;
+    private SFA <P,D> model;
+    private Boolean guardsInitialized;
+    private BooleanAlgebra <P,D> ba;
+    private AlgebraLearnerFactory <P,D> baLearnerFactory;
+	private Hashtable <String, Integer> perfCounters;
+	private Boolean repairedMissingLeaf; 
+
+	
+    public SFAAlgebraLearner(MembershipOracle <List<D>>m, BooleanAlgebra <P,D>b, 
+    		AlgebraLearnerFactory <P,D> balf) {
+    		membOracle = m;
+    		model = null;
+    		algebraLearners = new HashMap <>();
+    		modelGuards = new HashMap<>();
+    		ba = b;
+    		guardsInitialized = false;
+    		baLearnerFactory = balf;
+    		perfCounters = new Hashtable <>();
+    		repairedMissingLeaf = false;
+    		
+    		// Initialize the performance counters we keep
+    		perfCounters.put("CEGuardUpdates", 0);
+    		perfCounters.put("CEStateUpdates", 0);
+    		perfCounters.put("CEDet", 0);
+    		perfCounters.put("CEComp", 0);
+    }	
+    
+    private void incPerfCounter(String key) {
+    		if (!perfCounters.containsKey(key)) {
+    			throw new AssertionError("Invalid performance counter requested");
+    		}
+    		perfCounters.put(key, perfCounters.get(key) + 1);
+    		return;
+    }
+    
+    /*********************** Model construction    ************************/
+    
+    private SFA <P,D> copyModelClean() throws TimeoutException {    		    	
+    		return SFA.MkSFA(model.getTransitions(), model.getInitialState(), model.getFinalStates(), ba);    	
+    }
+    
+    /**
+     * Check that the guard set of outgoing transitions from srcState form a complete partition 
+     * of the alphabet otherwise provide the necessary counterexamples to the underlying 
+     * predicate learners.
+     * 
+     * @param srcState the id of the state to be checked.
+     * @param srcAs the access string for srcState.
+     * @return true if the guards where updated, false otherwise.
+     * @throws TimeoutException
+     */
+    private boolean makeGuardsComplete(Integer srcState, List <D>srcAs) throws TimeoutException {
+    		
+    		// Create a the OR of the predicates and check if it is satisfiable, 
+    		// negate it and check SAT. If SAT sat then we have a transition which is not there.
+    		P guardOrPredicate, guard, pnot;
+    		D witness;
+    		HashSet <P> guardSet = new HashSet <>();
+    		boolean updated = false;
+    		Pair <Integer, Integer> stPair;
+    		Integer ceTargetStateId, totalStates = tree.getLeafs().size();
+    		boolean wasFixedBefore = false;
+
+    		AlgebraLearner<P, D> guardLearner;
+    		List <D> ceTargetAs;
+     		
+    		while (true) {
+        		List <D> counterexample = new LinkedList <>(srcAs);
+    			for (Integer trgState = 0; trgState < totalStates; trgState ++) {
+    				stPair = new Pair <>(srcState, trgState);
+    				if (modelGuards.get(stPair) == null) {
+    					throw new AssertionError("null guard found to " + trgState);
+    				}
+    				guardSet.add(modelGuards.get(stPair));  					
+    			}		    			    			
+    			guardOrPredicate = ba.MkOr(guardSet);    			
+    			pnot = ba.MkNot(guardOrPredicate);
+    			if (!ba.IsSatisfiable(pnot)) {
+    				return updated;
+    			}
+    			witness = ba.generateWitness(pnot);
+    			incPerfCounter("CEComp");
+    			updated = true;
+    			// We have a counterexample: Find the wrong predicate(s) and update them.
+    			counterexample.add(witness);
+    			ceTargetAs = tree.sift(counterexample);
+    			if (ceTargetAs == null) {
+    				tree.fixMissingAccessSequence(counterexample);
+    				repairedMissingLeaf = true;
+    				return false;
+    			}
+    			ceTargetStateId = tree.getLeafs().indexOf(ceTargetAs);    	
+			stPair = new Pair <>(srcState, ceTargetStateId);
+			guard = modelGuards.get(stPair);			
+			guardLearner = algebraLearners.get(stPair);    						
+			wasFixedBefore = tree.isTreeComplete();
+			guard = guardLearner.updateModel(witness);			
+			modelGuards.put(stPair, guard);			
+			if (!wasFixedBefore && tree.isTreeComplete()) {
+				repairedMissingLeaf = true;
+				return false;
+			}			
+    		} // End while
+    		// Never reached    	
+    }
+    
+    /**
+     * Checks whether the set of outgoing transitions from state srcState is deterministic and 
+     * in the opposite case provides the appropriate counterexamples to the underlying algebra 
+     * learning instances.
+     *
+     * @param srcState the id of the state to be checked.
+     * @param srcAs the access string for the srcState.
+     * @return true if any guard was updated, false otherwise.
+     * @throws TimeoutException
+     */
+    private boolean makeGuardsDeterministic(Integer srcState, List <D>srcAs) 
+    		throws TimeoutException {      
+    		Integer ceTargetState, totalStates = tree.getLeafs().size();
+    		D witness;
+    		boolean updatedOverall = false, updatedRound;
+    		List <D> counterexample = new LinkedList <>(srcAs);
+    		AlgebraLearner<P, D> learner;
+    		List <Pair<Integer, P>> candidates;
+    		P g1, g2, newGuard, pand;
+    		
+    		while (true) {
+    			updatedRound = false;
+	    		for (Integer t1 = 0; t1 < totalStates; t1 ++) {
+	    			for (Integer t2 = 0; t2 < totalStates; t2 ++) {
+	    				if (t1.equals(t2)) {
+	    					continue;
+	    				}
+	    				g1 = modelGuards.get(new Pair <>(srcState, t1));
+	    				g2 = modelGuards.get(new Pair <>(srcState, t2));	    				
+	    				pand = ba.MkAnd(g1,g2);
+	    				if (!ba.IsSatisfiable(pand)) {
+	    					continue;
+	    				}
+	    				witness = ba.generateWitness(pand);
+	    				updatedOverall = updatedRound = true;
+	    				/* We have a counterexample */	    				
+	        			counterexample.add(witness);
+	        			if (tree.sift(counterexample) == null) {
+	        				tree.fixMissingAccessSequence(counterexample);
+	        				repairedMissingLeaf = true;
+	        				return false;
+	        			}
+	        			ceTargetState = tree.getLeafs().indexOf(tree.sift(counterexample));
+	        			incPerfCounter("CEDet");
+	        			/* Add both on a list so we won't be repeating code blocks */
+	        			candidates = new LinkedList <Pair<Integer, P>>();
+	        			candidates.add(new Pair<>(t1, g1));
+	        			candidates.add(new Pair<>(t2, g2));
+	        			for (Pair <Integer, P> gtp : candidates) {	        			
+	        				if ((ceTargetState.equals(gtp.getFirst())) != 
+	        						ba.HasModel(gtp.getSecond(), witness)) {	        					
+	        					learner = algebraLearners.get(new Pair<>(srcState, gtp.getFirst()));
+	        					newGuard = learner.updateModel(witness);
+	        					modelGuards.put(new Pair<>(srcState, gtp.getFirst()), newGuard);
+	        				}
+	        			}
+	        			counterexample.remove(counterexample.size()-1);	        				
+	    			} // Internal For
+	    		} // External for
+	    		if (!updatedRound) {
+	    			return updatedOverall;
+	    		}
+    		} // End While
+    		// Never reached
+    }
+
+    /**
+     * Repeatedly call the makeGuardsComplete and makeGuardsDeterministic method until convergence.
+     * 
+     * @param srcStateId the id of the state for which the guard set is to be tested.
+     * @param srcAs the access string for srcStateId.
+     * @throws TimeoutException
+     */
+    private void makeCompleteAndDeterministic(Integer srcStateId, List <D> srcAs) 
+    		throws TimeoutException {
+    		Boolean notComplete, notDeterministic;
+    		notComplete = false;
+    		notDeterministic = false;
+    		do {
+    			notComplete = makeGuardsComplete(srcStateId, srcAs);
+    			if (repairedMissingLeaf) {
+    				return;
+    			}
+    			notDeterministic = makeGuardsDeterministic(srcStateId, srcAs);    	    			
+    		} while (notComplete || notDeterministic);	
+    }
+    
+    /**
+     * Construct the guards of the SFA model by spawning one predicate learning algorithm instance
+     * for each pair of states and inferring the guard (or the lack of any guard) between this pair. 
+     * 
+     * @throws TimeoutException
+     */
+    private void constructGuards() throws TimeoutException {
+    		Integer totalStates = tree.getLeafs().size();
+		List <D> srcAs = null;
+		List <D> trgAs = null;
+		boolean changed;
+		
+    		for (Integer srcState = 0; srcState < totalStates; srcState ++) {    			
+    			changed = false;
+    			for (Integer trgState = 0; trgState < totalStates; trgState ++) {    	
+        			// Skip states for which the guards are constructed and no update is needed        			 
+    				if (modelGuards.containsKey(new Pair<Integer, Integer>(srcState, trgState))) {
+    					continue;
+    				}
+    				changed = true;    				
+    				Pair <Integer, Integer> stPair = new Pair <>(srcState, trgState);
+    				srcAs = tree.getLeafs().get(srcState);
+    				trgAs = tree.getLeafs().get(trgState);
+    				BALearnerSimulatedMembershipOracle <D> baMembOracle = 
+    						new BALearnerSimulatedMembershipOracle <>(tree, srcAs, trgAs);
+    				AlgebraLearner <P,D> guardLearner = 
+    						baLearnerFactory.getBALearner(baMembOracle); 
+    				P guard;
+    				
+    				// Everything is set up: learn guard predicate 
+    				guard = guardLearner.getModel();    				
+    				// Save everything 
+    				algebraLearners.put(stPair, guardLearner);
+    				if (guard == null) {
+    					throw new AssertionError("An empty (null) guard was added");
+    				}
+    				modelGuards.put(stPair, guard);
+    				if (baMembOracle.foundMissingLeaf()) {
+    					repairedMissingLeaf = true;
+    					return;
+    				}
+    			}	
+    			// make this check only if some guard was updated 
+    			if (changed) {
+    				makeCompleteAndDeterministic(srcState, srcAs);
+    			}
+    		}    		
+        return;
+    }
+
+	/**
+	 * Construct the SFA model by spawning the learning algorithms for the underlying predicates.
+	 * 
+	 * @return the SFA model based on the discrimination tree built so far.
+	 * @throws TimeoutException
+	 */
+    private SFA<P,D> constructModel() throws TimeoutException {    	
+    		// constructGuards and then use the tree to generate the SFA.
+    		if (!guardsInitialized) {
+    			/* 
+    			 * This may require two calls in case we fix the missing 
+    			 * leaf in the discrimination tree. 
+    			 */    			
+    			constructGuards();
+    			if (repairedMissingLeaf) {
+    				constructGuards();
+    				repairedMissingLeaf = false;
+    			}
+    		}		
+    		// Build Transitions 
+    		List <SFAMove <P,D>> transitions = new LinkedList <>();
+    		for (HashMap.Entry<Pair<Integer, Integer>, P> entry : modelGuards.entrySet()) {    			
+    			Pair <Integer, Integer> stPair = entry.getKey();
+    			P guard = entry.getValue();
+    			// Do not add empty transitions in the SFA model 
+    			if (ba.AreEquivalent(guard, ba.False())) {
+    				continue;
+    			}
+    			transitions.add(new SFAInputMove <P,D>(stPair.getFirst(), stPair.getSecond(), guard));    			    			
+    		}
+    		// Determine Final States 
+    		List <Integer> finalStates = new LinkedList <Integer>();
+    		Integer stateId = 0;
+    		for (List <D>accessString : tree.getLeafs()) {    			
+    			if (membOracle.query(accessString)) {
+    				finalStates.add(stateId);
+    			}
+    			stateId ++;
+    		}
+    		// Construct the final SFA model and return a fresh copy back to the caller.
+    		model = SFA.MkSFA(transitions, 0, finalStates, ba, false, false, true);
+        return copyModelClean();
+    }
+
+          
+    /******************* Counterexample Processing  ********************/
+    
+    /**
+     * Run the provided input in the SFA model and return the identifier of the state in which
+     * the input ends up. 
+     * 
+     * @param inp The input to run in the model.
+     * @return The id of the state where the input ends up in the model.
+     * @throws TimeoutException
+     */
+    private Integer modelGetTargetState(List <D> inp) throws TimeoutException {
+        Integer currentState = 0;
+        boolean found;
+        for (D currentSymbol : inp) {
+        		found = false;
+            for (SFAInputMove<P, D> ct : model.getInputMovesFrom(currentState)) {
+                if (ct.hasModel(currentSymbol, ba)) {                	
+                    currentState = ct.to;
+                    found = true;
+                    break;
+                }                            
+            }
+            if (!found) {
+            		throw new AssertionError("Incomplete model in counterexample processing");
+            }            
+        }
+        return currentState;
+    }
+    
+    /**
+     * Given the breakpoint where the execution of the target and the model diverge, distinguish 
+     * between a counterexample due to a hidden state in the target or a counterexample due to
+     * an invalid predicate and handle the counterexample accordingly.
+     * 
+     * @param ce the provided counterexample
+     * @param index the index of the breakpoint in the counterexample.
+     * @throws TimeoutException
+     */    
+    private void analyzeBreakpoint(List <D> ce, int index) throws TimeoutException {    		
+    		// index here should be the index such that ce.subList(0, index) is accessing the invalid state    		 
+    		List <D> srcAs, trgAs, newAs, newDist, trgPrefix;
+    		Integer srcStateId, trgStateId, modelTrgStateId;
+    		P newGuard, guard; 
+    		
+    		//srcAs = tree.sift(ce.subList(0, index));    		
+    		srcAs = tree.getLeafs().get(modelGetTargetState(new LinkedList<D>(ce.subList(0, index))));    		
+    		trgPrefix = new LinkedList <D>(srcAs);
+    		trgPrefix.add(ce.get(index));
+    		if ((trgAs = tree.sift(trgPrefix)) == null) {
+    			/* 
+    			 * The undiscovered new state is the missing leaf from the tree:
+    			 * We fix the missing leaf and return. This is the only case where no
+    			 * state splitting nor guard repairing is taking place.
+    			 */
+    			newAs = new LinkedList <D>(srcAs);
+    			newAs.add(ce.get(index));
+    			tree.fixMissingAccessSequence(newAs);
+    			return;    			
+    		}
+    		srcStateId = tree.getLeafs().indexOf(srcAs);
+    		trgStateId = tree.getLeafs().indexOf(trgAs);
+    		modelTrgStateId = modelGetTargetState(new LinkedList<D>(ce.subList(0, index+1)));    		
+    		guard = modelGuards.get(new Pair<Integer, Integer>(srcStateId, trgStateId));
+    		if (ba.HasModel(guard, ce.get(index))) {
+    			// Guard is correct, we have an undiscovered state 
+    			incPerfCounter("CEStateUpdates");
+    			newDist = new LinkedList<D>(ce.subList(index+1, ce.size()));
+    			newAs = new LinkedList <D>(srcAs);
+    			newAs.add(ce.get(index));   
+    			tree.splitLeaf(trgAs, newDist, newAs);
+    			// Through away all learning instances that were directed to the old state that was split up 
+    			for (Integer sid = 0; sid < tree.getLeafs().size(); sid ++) {
+    				modelGuards.remove(new Pair<Integer, Integer>(sid, trgStateId));
+    			}    			    			
+    			return;
+    		}     		
+    		/* 
+    		 * We have an invalid guard predicate:
+    		 * Update both guards, the one that should take the transition and didn't and the 
+    		 * one that did take it but shouldn't, make the guard set complete and deterministic
+    		 * and make a new equivalence query.
+    		 */
+    		incPerfCounter("CEGuardUpdates");
+    		newGuard = algebraLearners.get(new Pair<Integer, Integer>(srcStateId, trgStateId)).
+    				updateModel(ce.get(index));
+    		modelGuards.put(new Pair<Integer, Integer>(srcStateId, trgStateId), newGuard);
+    		newGuard = algebraLearners.get(new Pair<Integer, Integer>(srcStateId, modelTrgStateId)).
+    				updateModel(ce.get(index));
+    		modelGuards.put(new Pair<Integer, Integer>(srcStateId, modelTrgStateId), newGuard);
+    		makeCompleteAndDeterministic(srcStateId, srcAs);
+        return;
+    }
+
+    /**
+     * Process a counterexample to the current model and either add a node in the discrimination tree
+     * or provide a counterexample to one of the underlying algebra learners. The counterexample processing
+     * algorithm is using binary search in order to find the breakpoint where the model and the target 
+     * diverge. 
+     * 
+     * @param ce the counterexample to the current model
+     * @throws TimeoutException
+     */
+    private void proccessCounterexample(List <D> ce) throws TimeoutException {    		
+    		List <D>prefix = new LinkedList <>();
+    		boolean ceOut = membOracle.query(ce);
+    		Integer index = 0, curState;
+    		List <D> curAs;
+    		List <D> curQuery;
+    		
+    		Integer correctIdx, incorrectIdx, high, low;
+    		correctIdx = -1;
+    		incorrectIdx = ce.size();
+    		low = 0;
+    		high = ce.size() - 1;
+    		while (incorrectIdx != correctIdx+1) {
+        		index = (low + high)/2;        		
+    			prefix = new LinkedList <D>(ce.subList(0, index+1));    			    		
+    			curState = modelGetTargetState(prefix);
+    			curAs = tree.getLeafs().get(curState);    			
+    			curQuery = new LinkedList <D>(curAs);
+    			curQuery.addAll(new LinkedList <D>(ce.subList(index+1, ce.size())));    
+    			if (membOracle.query(curQuery) != ceOut) {
+    				incorrectIdx = index;
+    				high = index;
+    			} else {
+    				correctIdx = index;
+    				low = index + 1;
+    			}	
+    		} // End While
+    		analyzeBreakpoint(ce, high);    		
+    }
+
+
+    /************************** Public Methods  ****************************/
+
+    public Integer getNumCEStateUpdates() { 
+    		return perfCounters.get("CEStateUpdates");
+    }
+    
+    public Integer getNumCEGuardUpdates() {
+    		return perfCounters.get("CEGuardUpdates");
+    }
+    
+    public Integer getNumDetCE() {
+    		return perfCounters.get("CEDet");
+    }
+    
+    public Integer getNumCompCE() {
+    		return perfCounters.get("CEComp");
+    }
+    
+    /***********  Learning API  ***********/
+    
+    public SFA <P,D> getModel() throws TimeoutException {
+    		tree = new DiscriminationTree <D> (membOracle);    		
+        return constructModel();
+    }
+
+    public SFA <P,D> updateModel(List <D> counterexample) throws TimeoutException {
+        if (model == null) {
+            throw new AssertionError("UpdateModel called without first building a model");
+        } else if (model.accepts(counterexample, ba) == membOracle.query(counterexample)) {
+        		throw new AssertionError("Counterexample given is not a counterexample");
+        }        
+        proccessCounterexample(counterexample);
+        return constructModel();           		
+    }
+
+    public SFA <P,D> getModelFinal(EquivalenceOracle <SFA <P, D>, List <D>> equiv) throws TimeoutException {
+        List <D> ce;
+        SFA <P,D> cleanModel = getModel();
+        while ((ce = equiv.getCounterexample(cleanModel)) != null) {
+        		cleanModel = updateModel(ce);
+        }
+        return cleanModel;
+    }
+    	
+}

--- a/SVPAlib/src/algebralearning/sfa/SFAAlgebraLearnerFactory.java
+++ b/SVPAlib/src/algebralearning/sfa/SFAAlgebraLearnerFactory.java
@@ -1,0 +1,27 @@
+package algebralearning.sfa;
+
+import java.util.List;
+
+import algebralearning.AlgebraLearner;
+import algebralearning.AlgebraLearnerFactory;
+import algebralearning.oracles.MembershipOracle;
+import automata.sfa.SFA;
+import theory.BooleanAlgebra;
+
+public class SFAAlgebraLearnerFactory <P,D> extends AlgebraLearnerFactory <SFA <P,D>, List <D>> {
+
+	private AlgebraLearnerFactory <P,D> baLearnerFactory;
+	private BooleanAlgebra <P,D> ba;
+	
+	public SFAAlgebraLearnerFactory(AlgebraLearnerFactory <P,D>balf, BooleanAlgebra <P,D>b) {
+		baLearnerFactory = balf;
+		ba = b;
+	}
+	
+	@Override
+	public AlgebraLearner <SFA <P,D>, List <D>> getBALearner(MembershipOracle <List<D>> m) {
+			//return new SFAAlgebraLearner(m, ba, baLearnerFactory);
+		return new SFAAlgebraLearner <P,D> (m, ba, baLearnerFactory);
+	}
+
+}

--- a/SVPAlib/src/algebralearning/sfa/SFAEquivalenceOracle.java
+++ b/SVPAlib/src/algebralearning/sfa/SFAEquivalenceOracle.java
@@ -1,0 +1,101 @@
+/**
+ * Equivalence oracle instantiation for the SFA algebra.
+ * @author George Argyros
+ */
+
+package algebralearning.sfa;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.oracles.EquivalenceOracle;
+import automata.sfa.SFA;
+import theory.BooleanAlgebra;
+
+/**
+ * Implements the equivalence oracle for SFAs. 
+ * 
+ * @param <P> The type of predicates in the target SFA. 
+ * @param <D> The domain of the algebra of the target SFA.
+ */
+public class SFAEquivalenceOracle <P,D> extends EquivalenceOracle <SFA <P,D>, List <D>> {
+
+	private SFA <P,D> correctModel;
+	private BooleanAlgebra <P,D> ba;
+	private List <D> cachedCe; 	
+	private Integer distinctCeNum;
+	private Integer cachedCeNum;
+	
+	/**
+	 * 
+	 * @param cModel the target SFA for which equivalence will be checked against.
+	 * @param b the boolean algebra used by the cModel SFA.
+	 */
+	public SFAEquivalenceOracle(SFA <P,D> cModel, BooleanAlgebra <P,D> b) {		
+		correctModel = cModel;
+		ba = b;
+		distinctCeNum = 0;
+		cachedCeNum = 0;
+		// cachedCe contains the last counterexample and the model is checked against it before 
+		// invoking the more expensive equivalence test. 
+		cachedCe = null;
+	}
+
+	/**
+	 * Internal method to compare the provided model with the correctModel SFA.
+	 * 
+	 * @param model model to compare against.
+	 * @return An input under which the two models differ or null if they are equivalent.
+	 * @throws TimeoutException
+	 */
+	private List<D> compareWithTarget(SFA <P,D> model) throws TimeoutException {
+		
+		SFA <P,D> diff;
+		
+		diff = model.complement(ba);
+		diff = diff.intersectionWith(correctModel, ba);
+		if (!diff.isEmpty()) {
+			return diff.getWitness(ba);
+		}
+		diff = correctModel.complement(ba);
+		diff = diff.intersectionWith(model, ba);
+		if (!diff.isEmpty()) {
+			return diff.getWitness(ba);
+		}		
+		return null;		
+	}
+    
+    public List <D>getCounterexample (SFA <P,D> model) throws TimeoutException {
+    		List <D> ce;
+    		
+    		if ((cachedCe != null) && 
+    				(model.accepts(cachedCe, ba) != correctModel.accepts(cachedCe, ba))) {
+    			cachedCeNum ++;
+    			return cachedCe;
+    		}    			    		
+    		ce = compareWithTarget(model);    		
+    		if (ce == null) {    			
+    			return null;
+    		} else {    			
+    			cachedCe = new LinkedList <D>(ce);
+    			distinctCeNum ++;
+    			return ce;
+    		}
+    }
+
+    /**
+     * @return the number of cached counterexamples used so far.
+     */
+    	public Integer getCachedCeNum() {
+    		   return cachedCeNum; 		
+    	}
+    	
+    	/**
+    	 * @return the number of distinct counterexamples used so far.
+    	 */
+    	public Integer getDistinctCeNum() {
+ 		   return distinctCeNum; 		
+ 	}    	
+}

--- a/SVPAlib/src/algebralearning/sfa/SFAMembershipOracle.java
+++ b/SVPAlib/src/algebralearning/sfa/SFAMembershipOracle.java
@@ -1,0 +1,81 @@
+/**
+ * Membership oracle instantiation for the SFA algebra.
+ * @author George Argyros
+ */
+package algebralearning.sfa;
+
+import java.util.Hashtable;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.oracles.MembershipOracle;
+import automata.sfa.SFA;
+import theory.BooleanAlgebra;
+/**
+ * 
+ * Membership oracle class used by the SFA Learning algorithm implementation.
+ *
+ * @param <P> The type of predicates used by the SFA.
+ * @param <D> The underlying domain used by the SFA.
+ */
+public class SFAMembershipOracle <P, D> extends MembershipOracle <List<D>> {
+	
+	private SFA <P,D> sfa;
+	private BooleanAlgebra <P,D> ba;
+	private Hashtable <List<D>, Boolean> cache;	
+	private Integer distinctQueries;
+	private Integer cachedQueries;
+	
+	/**
+	 *  
+	 * @param target the SFA which is to be queried.
+	 * @param b The boolean algebra used by the target SFA.
+	 */
+	public SFAMembershipOracle(SFA <P,D> target, BooleanAlgebra <P,D> b) {		
+		if (target == null || b == null) {
+			throw new AssertionError("SFA and boolean algebra cannot be null");
+		}		
+		sfa = target;
+		ba = b;
+		cache = new Hashtable<>();
+		distinctQueries = 0;
+		cachedQueries = 0;
+	}
+	
+	/**
+	 * 
+	 * @param input the input for the target SFA.
+	 * @return true/false depending whether sfa accepts or rejects input.
+	 */
+	public boolean query(List <D> input) throws TimeoutException {		
+		Boolean res; 
+		if (input == null) {
+			throw new AssertionError("Null input in membership query");
+		}
+		if (cache.containsKey(input)) {
+			cachedQueries ++;
+			return cache.get(input);
+		}
+		distinctQueries ++;
+		res = sfa.accepts(input, ba);
+		cache.put(new LinkedList <D>(input), res);
+		return res;
+	}
+	
+	/**
+	 * @return the number of distinct queries performed so far.
+	 */
+	public Integer getDistinctQueries() {
+		return distinctQueries;
+	}
+	/**
+	 * @return the number of cached queries performed so far.
+	 */
+	public Integer getCachedQueries() {
+		return cachedQueries;
+	}
+	
+	
+}

--- a/SVPAlib/src/automata/sfa/SFA.java
+++ b/SVPAlib/src/automata/sfa/SFA.java
@@ -149,7 +149,8 @@ public class SFA<P, S> extends Automaton<P, S> {
 
 		return MkSFA(transitions, initialState, finalStates, ba, true);
 	}
-
+	
+	
 	/**
 	 * Create an automaton and removes unreachable states and only removes
 	 * unreachable states if <code>remUnreachableStates<code> is true
@@ -168,7 +169,7 @@ public class SFA<P, S> extends Automaton<P, S> {
 	 * unreachable states if remUnreachableStates is true and normalizes the
 	 * automaton if normalize is true
 	 */
-	private static <A, B> SFA<A, B> MkSFA(Collection<SFAMove<A, B>> transitions, Integer initialState,
+	public static <A, B> SFA<A, B> MkSFA(Collection<SFAMove<A, B>> transitions, Integer initialState,
 			Collection<Integer> finalStates, BooleanAlgebra<A, B> ba, boolean remUnreachableStates, boolean normalize)
 					throws TimeoutException {
 
@@ -198,6 +199,39 @@ public class SFA<P, S> extends Automaton<P, S> {
 		return aut;
 	}
 
+	/**
+	 * Gives the option to create an automaton exactly as given by the parameters, avoiding all normalizations.
+	 * 
+	 * @throws TimeoutException
+	 */
+	public static <A, B> SFA<A, B> MkSFA(Collection<SFAMove<A, B>> transitions, Integer initialState,
+			Collection<Integer> finalStates, BooleanAlgebra<A, B> ba, boolean remUnreachableStates, boolean normalize, boolean keepEmpty)  
+					throws TimeoutException{
+		SFA<A, B> aut = new SFA<A, B>();
+
+		aut.states = new HashSet<Integer>();
+		aut.states.add(initialState);
+		aut.states.addAll(finalStates);
+
+		aut.initialState = initialState;
+		aut.finalStates = finalStates;
+
+		for (SFAMove<A, B> t : transitions)
+			aut.addTransition(t, ba, true);
+
+		if (normalize)
+			aut = aut.normalize(ba);
+
+		if (remUnreachableStates)
+			aut = removeDeadOrUnreachableStates(aut, ba);
+
+		if (aut.finalStates.isEmpty() && !keepEmpty)
+			return getEmptySFA(ba);
+
+		return aut;
+	}
+	
+	
 	// Adds a transition to the SFA
 	private void addTransition(SFAMove<P, S> transition, BooleanAlgebra<P, S> ba, boolean skipSatCheck) throws TimeoutException {
 

--- a/TestSVPA/src/test/algebralearning/equality/EqualityLearnerUnitTest.java
+++ b/TestSVPA/src/test/algebralearning/equality/EqualityLearnerUnitTest.java
@@ -1,0 +1,42 @@
+package test.algebralearning.equality;
+
+import org.junit.Test;
+import static org.junit.Assert.assertTrue;
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.equality.EqualityAlgebraLearner;
+import algebralearning.equality.EqualityEquivalenceOracle;
+import algebralearning.equality.EqualityMembershipOracle;
+import theory.characters.CharPred;
+import theory.intervals.UnaryCharIntervalSolver;
+
+
+public class EqualityLearnerUnitTest {
+
+	
+	@Test
+	public void EqualityLearnerTest1() throws TimeoutException {
+		UnaryCharIntervalSolver ba = new UnaryCharIntervalSolver();
+		CharPred model, target = ba.MkAtom('a');
+		target = ba.MkOr(target, ba.MkAtom('b'));		
+		EqualityMembershipOracle<CharPred, Character> memb = new EqualityMembershipOracle<>(target, ba);
+		EqualityEquivalenceOracle<CharPred, Character> equiv = new EqualityEquivalenceOracle<>(target, ba);		
+		EqualityAlgebraLearner <CharPred, Character> learner = new EqualityAlgebraLearner<>(memb, ba);
+		model = learner.getModelFinal(equiv);
+		assertTrue(model.equals(target));				
+	}
+	
+	@Test
+	public void EqualityLearnerTest2() throws TimeoutException {
+		UnaryCharIntervalSolver ba = new UnaryCharIntervalSolver();
+		CharPred model, target = ba.MkAtom('a');
+		target = ba.MkOr(target, ba.MkAtom('b'));
+		target = ba.MkNot(target);		
+		EqualityMembershipOracle<CharPred, Character> memb = new EqualityMembershipOracle<>(target, ba);
+		EqualityEquivalenceOracle<CharPred, Character> equiv = new EqualityEquivalenceOracle<>(target, ba);		
+		EqualityAlgebraLearner <CharPred, Character> learner = new EqualityAlgebraLearner<>(memb, ba);
+		model = learner.getModelFinal(equiv);
+		assertTrue(model.equals(target));				
+	}
+	
+}

--- a/TestSVPA/src/test/algebralearning/sfa/SFALearnerUnitTest.java
+++ b/TestSVPA/src/test/algebralearning/sfa/SFALearnerUnitTest.java
@@ -1,0 +1,55 @@
+
+package test.algebralearning.sfa;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.sat4j.specs.TimeoutException;
+
+import algebralearning.equality.EqualityAlgebraLearnerFactory;
+import algebralearning.sfa.SFAAlgebraLearner;
+import algebralearning.sfa.SFAEquivalenceOracle;
+import algebralearning.sfa.SFAMembershipOracle;
+import automata.sfa.SFA;
+import benchmark.SFAprovider;
+import theory.characters.CharPred;
+import theory.intervals.UnaryCharIntervalSolver;
+
+import benchmark.algebralearning.RELearning;
+
+public class SFALearnerUnitTest {
+
+	@Test
+	public void testSFALearning1() throws TimeoutException {
+		UnaryCharIntervalSolver solver = new UnaryCharIntervalSolver();
+		SFAprovider provider = new SFAprovider("aaa", solver);			
+		SFA<CharPred, Character> model, sfa = provider.getSFA().determinize(solver).minimize(solver);
+		SFAMembershipOracle<CharPred, Character>memb = new SFAMembershipOracle<>(sfa, solver);
+		SFAEquivalenceOracle<CharPred, Character>equiv = new SFAEquivalenceOracle<>(sfa, solver);
+		EqualityAlgebraLearnerFactory<CharPred, Character> balf = new EqualityAlgebraLearnerFactory<>(solver);
+		SFAAlgebraLearner<CharPred, Character> learner = new SFAAlgebraLearner<>(memb, solver, balf);
+		
+		model = learner.getModelFinal(equiv);
+		assertTrue(model.isEquivalentTo(sfa, solver));					
+	}
+	
+	@Test
+	public void testSFALearning2() throws TimeoutException {
+		UnaryCharIntervalSolver solver = new UnaryCharIntervalSolver();
+		SFAprovider provider = new SFAprovider("<scrip(t|l)>s(.*)</script>", solver);			
+		SFA<CharPred, Character> model, sfa = provider.getSFA().determinize(solver).minimize(solver);
+		SFAMembershipOracle<CharPred, Character>memb = new SFAMembershipOracle<>(sfa, solver);
+		SFAEquivalenceOracle<CharPred, Character>equiv = new SFAEquivalenceOracle<>(sfa, solver);
+		EqualityAlgebraLearnerFactory<CharPred, Character> balf = new EqualityAlgebraLearnerFactory<>(solver);
+		SFAAlgebraLearner<CharPred, Character> learner = new SFAAlgebraLearner<>(memb, solver, balf);
+		
+		model = learner.getModelFinal(equiv);
+		assertTrue(model.isEquivalentTo(sfa, solver));					
+	}
+	
+	@Test
+	public void testRELearning() throws TimeoutException {
+		RELearning rel = new RELearning();
+		assertTrue(rel.learnREBenchmark(2) != null);		
+	}
+}


### PR DESCRIPTION
- This is for the main learning algorithm with equality algebra.
- The RE experiments are added in the SVPABenchmark as an RELearning class. 
- I did some minimal modifications in the SFA class to add a constructor which will retain even empty automata without throwing away states (needed by learning algorithm) and also made another constructor public.
- BDD  Algebra and SFAs over SFAs are not included in this commit, I will push them later this week.