### PR TITLE
Fix tests involving file imports in paths with spaces

### DIFF
--- a/models/src/test/java/SVPA/SVPAUnitTest.java
+++ b/models/src/test/java/SVPA/SVPAUnitTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -887,9 +888,9 @@ public class SVPAUnitTest {
 	}
 
 	private SVPA<ICharPred, Character> importFromResourceFile(
-			String file) throws AutomataException, IOException {
+			String file) throws AutomataException, IOException, URISyntaxException {
 		return ImportCharSVPA.importSVPA(
-			new File(getClass().getClassLoader().getResource(file).getFile()));
+			new File(getClass().getClassLoader().getResource(file).toURI().getPath()));
 	}
 
 	// slow intersection test (first_svpa_intersect is large)


### PR DESCRIPTION
Currently, tests involving file imports will fail if this repository is cloned in a directory that has whitespace in the path, e.g. `/tmp/Research project/symbolicautomata`. The resource loader uses the URL class, which automatically encodes all special characters to URL encoded charcters. This obviously causes issues on the file system, but this can be fixed by converting it to a URI first. Relevant information on StackOverflow: https://stackoverflow.com/a/13470643.