### PR TITLE
Fix and simplify regex repetition

### DIFF
--- a/benchmarks/src/main/java/regexconverter/RegexConverter.java
+++ b/benchmarks/src/main/java/regexconverter/RegexConverter.java
@@ -58,15 +58,13 @@ public class RegexConverter {
 			List<RegexNode> concateList = cphi.getList();
 			Iterator<RegexNode> it = concateList.iterator();
 			//initialize SFA to empty SFA
-			SFA<CharPred, Character> iterateSFA = SFA.getEmptySFA(unarySolver);
-			if(it.hasNext()){
-				iterateSFA = toSFA(it.next(), unarySolver);
-				while (it.hasNext()) {
-					SFA<CharPred, Character> followingSFA = toSFA(it.next(), unarySolver);
-					iterateSFA = SFA.concatenate(iterateSFA, followingSFA, unarySolver);
-				}
+			Collection<SFAMove<CharPred, Character>> transitionsA = new LinkedList<SFAMove<CharPred, Character>>();
+			outputSFA = SFA.MkSFA(transitionsA, 0, Arrays.asList(0), unarySolver);
+			while (it.hasNext()) {
+				SFA<CharPred, Character> followingSFA = toSFA(it.next(), unarySolver);
+				outputSFA = SFA.concatenate(outputSFA, followingSFA, unarySolver);
 			}
-			return iterateSFA;
+			return outputSFA;
 
 		} else if (phi instanceof DotNode) {
 			// make a SFA that has a transition which accepts TRUE
@@ -217,16 +215,10 @@ public class RegexConverter {
 
 		} else if (phi instanceof RepetitionNode) {
 			RepetitionNode cphi = (RepetitionNode) phi;
-			//special case when there is zero repetition which means the Regex is not existing
-			if(cphi.getMin() == 0){
-				return SFA.getEmptySFA(unarySolver);
-			}
-			//now the repetition will be at least once
+			Collection<SFAMove<CharPred, Character>> transitionsA = new LinkedList<SFAMove<CharPred, Character>>();
+			outputSFA = SFA.MkSFA(transitionsA, 0, Arrays.asList(0), unarySolver);
 			SFA<CharPred, Character> tempSFA = toSFA(cphi.getMyRegex1(), unarySolver);
-			//make sure there is no empty SFA when using SFA.concatenate()
-			outputSFA = tempSFA;
-			// i starts from 1 because we already have one repetition above
-			for (int i = 1; i < cphi.getMin(); i++) { //now we looped min times
+			for (int i = 0; i < cphi.getMin(); i++) { //now we looped min times
 				outputSFA = SFA.concatenate(outputSFA, tempSFA, unarySolver);
 			}
 			


### PR DESCRIPTION
There are two commits.

### fix: nullary concatenation language is not empty but contains just the empty word

Conversion of regex concatenation and repetition was unsound:

1. nullary concatenation (which luckily does not happen in real world) was being converted to an empty automaton but it should be the automaton that accepts just the empty word
2. repetition `x{0,n}` was converted to an empty automaton, which is a serious bug that affected also conversion of `benchmarks/src/main/java/regexconverter/pattern@75.txt`.

### RepetitionNode: simpler minToMax construction

I have removed copying in the repetition `x{a,b}`, which was unnecessarily causing quadratic complexity. For example, before this commit, the regex `^a{0,4}$` would be converted to:

```
STATES [0, 1, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 15, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
INIT 0
FINAL [32, 1, 5, 21, 12]
TRANS [E: 0 --> 33, E: 3 --> 4, S: 4 -[a]-> 5, E: 6 --> 1, E: 6 --> 3, E: 8 --> 9, S: 9 -[a]-> 10, E: 10 --> 11, S: 11 -[a]-> 12, E: 13 --> 8, E: 13 --> 6, E: 15 --> 16, S: 16 -[a]-> 17, E: 17 --> 18, S: 18 -[a]-> 19, E: 19 --> 20, S: 20 -[a]-> 21, E: 22 --> 15, E: 22 --> 13, E: 24 --> 25, S: 25 -[a]-> 26, E: 26 --> 27, S: 27 -[a]-> 28, E: 28 --> 29, S: 29 -[a]-> 30, E: 30 --> 31, S: 31 -[a]-> 32, E: 33 --> 24, E: 33 --> 22]
```

Note that there are as much as 10 `-[a]->` transitions.
I've changed it to:

```
STATES [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11, 12, 14, 15, 17, 18, 20, 21]
INIT 0
FINAL [17, 20, 9, 11, 14]
TRANS [E: 0 --> 1, E: 1 --> 21, S: 2 -[a]-> 3, E: 3 --> 18, S: 4 -[a]-> 5, E: 5 --> 15, S: 6 -[a]-> 7, E: 7 --> 12, S: 8 -[a]-> 9, E: 12 --> 11, E: 12 --> 8, E: 15 --> 6, E: 15 --> 14, E: 18 --> 17, E: 18 --> 4, E: 21 --> 2, E: 21 --> 20]
```

Note that there are only four `-[a]->` transitions, as one would expect.