### PR TITLE
fixed some == that should have been .equals

### DIFF
--- a/models/src/main/java/automata/svpa/Call.java
+++ b/models/src/main/java/automata/svpa/Call.java
@@ -78,7 +78,7 @@ public class Call<U,S> extends SVPAMove<U,S> {
 	public boolean equals(Object other) {
 		if (other instanceof Call<?, ?>) {
 			Call<?, ?> otherCasted = (Call<?, ?>) other;
-			return otherCasted.from==from && otherCasted.to==to && otherCasted.guard==guard && otherCasted.stackState==stackState;
+			return otherCasted.from.equals(from) && otherCasted.to.equals(to) && otherCasted.guard.equals(guard) && otherCasted.stackState.equals(stackState);
 		}
 
 		return false;

--- a/models/src/main/java/automata/svpa/Internal.java
+++ b/models/src/main/java/automata/svpa/Internal.java
@@ -49,7 +49,7 @@ public class Internal<U, S> extends SVPAMove<U, S> {
 
 		if (input.tag == SymbolTag.Internal) {
 			Integer currState = state.first;
-			if (currState == from) {
+			if (currState.equals(from)) {
 				Stack<Pair<Integer, S>> currStack = state.second;
 				if (ba.HasModel(guard, input.input)) {
 					@SuppressWarnings("unchecked")
@@ -79,7 +79,7 @@ public class Internal<U, S> extends SVPAMove<U, S> {
 	public boolean equals(Object other) {
 		if (other instanceof Internal<?, ?>) {
 			Internal<?, ?> otherCasted = (Internal<?, ?>) other;
-			return otherCasted.from==from && otherCasted.to==to && otherCasted.guard==guard;
+			return otherCasted.from.equals(from) && otherCasted.to.equals(to) && otherCasted.guard.equals(guard);
 		}
 
 		return false;

--- a/models/src/main/java/automata/svpa/Return.java
+++ b/models/src/main/java/automata/svpa/Return.java
@@ -32,7 +32,7 @@ public class Return<U, S> extends SVPAMove<U, S> {
 
 	public boolean isDisjointFrom(SVPAMove<U, S> t, BooleanAlgebra<U, S> ba) throws TimeoutException {
 		if (t instanceof Return)
-			if (from.equals(t.from) && stackState == ((Return<U, S>) t).stackState){
+			if (from.equals(t.from) && stackState.equals(((Return<U, S>) t).stackState)){
 				List<U> conjuncts = new ArrayList<U>();
 				conjuncts.add(guard);
 				conjuncts.add(((Return<U, S>) t).guard);
@@ -51,12 +51,12 @@ public class Return<U, S> extends SVPAMove<U, S> {
 			TaggedSymbol<S> input, BooleanAlgebra<U, S> ba) throws TimeoutException {
 		if (input.tag == SymbolTag.Return) {
 			Integer currState = state.first;
-			if (currState == from) {
+			if (currState.equals(from)) {
 				Stack<Pair<Integer, S>> currStack = state.second;
 				if (currStack.size() > 0) {
 					Pair<Integer, S> stackTop = currStack.peek();
 
-					if (stackTop.first == stackState
+					if (stackTop.first.equals(stackState)
 							&& ba.HasModel(guard, stackTop.second, input.input)) {
 						@SuppressWarnings("unchecked")
 						Stack<Pair<Integer, S>> newStack = (Stack<Pair<Integer, S>>) currStack
@@ -93,9 +93,9 @@ public class Return<U, S> extends SVPAMove<U, S> {
 	public boolean equals(Object other) {
 		if (other instanceof Return<?, ?>) {
 			Return<?, ?> otherCasted = (Return<?, ?>) other;
-			return otherCasted.from == from && otherCasted.to == to
-					&& otherCasted.guard == guard
-					&& otherCasted.stackState == stackState;
+			return otherCasted.from.equals(from) && otherCasted.to.equals(to)
+					&& otherCasted.guard.equals(guard)
+					&& otherCasted.stackState.equals(stackState);
 		}
 
 		return false;

--- a/models/src/main/java/automata/svpa/ReturnBS.java
+++ b/models/src/main/java/automata/svpa/ReturnBS.java
@@ -51,7 +51,7 @@ public class ReturnBS<U, S> extends SVPAMove<U, S> {
 		
 		if (input.tag == SymbolTag.Return) {
 			Integer currState = state.first;
-			if (currState == from) {
+			if (currState.equals(from)) {
 				Stack<Pair<Integer, S>> currStack = state.second;
 
 				if (currStack.size() == 0
@@ -88,7 +88,7 @@ public class ReturnBS<U, S> extends SVPAMove<U, S> {
 	public boolean equals(Object other) {
 		if (other instanceof ReturnBS<?, ?>) {
 			ReturnBS<?, ?> otherCasted = (ReturnBS<?, ?>) other;
-			return otherCasted.from==from && otherCasted.to==to && otherCasted.guard==guard;
+			return otherCasted.from.equals(from) && otherCasted.to.equals(to) && otherCasted.guard.equals(guard);
 		}
 
 		return false;

--- a/models/src/main/java/automata/svpa/SVPA.java
+++ b/models/src/main/java/automata/svpa/SVPA.java
@@ -1060,7 +1060,7 @@ public class SVPA<U, S> extends VPAutomaton<U, S> {
 			Collection<Pair<Integer, Integer>> state, Integer fst) {
 		HashSet<Pair<Integer, Integer>> sc = new HashSet<Pair<Integer, Integer>>();
 		for (Pair<Integer, Integer> st : state)
-			if (st.first == fst)
+			if (st.first.equals(fst))
 				sc.add(st);
 		return sc;
 	}
@@ -1069,7 +1069,7 @@ public class SVPA<U, S> extends VPAutomaton<U, S> {
 			Collection<Pair<Integer, Integer>> state, Integer sec) {
 		HashSet<Pair<Integer, Integer>> sc = new HashSet<Pair<Integer, Integer>>();
 		for (Pair<Integer, Integer> st : state)
-			if (st.second == sec)
+			if (st.second.equals(sec))
 				sc.add(st);
 		return sc;
 	}
@@ -1280,7 +1280,7 @@ public class SVPA<U, S> extends VPAutomaton<U, S> {
 
 		Collection<Call<U, S>> output = new HashSet<Call<U, S>>();
 		for (Call<U, S> call : trset)
-			if (call.stackState == stackState)
+			if (call.stackState.equals(stackState))
 				output.add(call);
 		return output;
 	}
@@ -1621,7 +1621,7 @@ public class SVPA<U, S> extends VPAutomaton<U, S> {
 			BooleanAlgebra<U, S> ba, boolean skipSatCheck) throws TimeoutException {
 
 		if (transition.isEpsilonTransition()) {
-			if (transition.to == transition.from)
+			if (transition.to.equals(transition.from))
 				return;
 			isEpsilonFree = false;
 		}

--- a/models/src/main/java/automata/svpa/SVPAEpsilon.java
+++ b/models/src/main/java/automata/svpa/SVPAEpsilon.java
@@ -21,7 +21,7 @@ public class SVPAEpsilon<U, S> extends SVPAMove<U, S> {
 	}
 
 	public boolean isDisjointFrom(SVPAMove<U, S> t, BooleanAlgebra<U, S> ba) {
-		return t.from != from;
+		return !t.from.equals(from);
 	}
 
 	public boolean isSatisfiable(BooleanAlgebra<U, S> boolal) {
@@ -54,7 +54,7 @@ public class SVPAEpsilon<U, S> extends SVPAMove<U, S> {
 	public boolean equals(Object other) {
 		if (other instanceof SVPAEpsilon<?, ?>) {
 			SVPAEpsilon<?, ?> otherCasted = (SVPAEpsilon<?, ?>) other;
-			return otherCasted.from == from && otherCasted.to == to;
+			return otherCasted.from.equals(from) && otherCasted.to.equals(to);
 		}
 
 		return false;


### PR DESCRIPTION
I spotted a few equality checks between Integers using == instead of .equals().

The resulting errors were tricky to catch: the JVM caches Integer objects between -128 and 127, so the related problems were appearing only when working on larger automata.