### PR TITLE
Added hashCode functions to several Move types

### DIFF
--- a/models/src/main/java/automata/esfa/ESFAEpsilon.java
+++ b/models/src/main/java/automata/esfa/ESFAEpsilon.java
@@ -1,6 +1,7 @@
 package automata.esfa;
 
 import java.util.List;
+import java.util.Objects;
 
 import automata.esfa.ESFAMove;
 import theory.BooleanAlgebra;
@@ -43,6 +44,11 @@ public class ESFAEpsilon<U,S> extends ESFAMove<U,S> {
 		}
 
 		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(to, from);
 	}
 	
 	@Override

--- a/models/src/main/java/automata/safa/SAFAInputMove.java
+++ b/models/src/main/java/automata/safa/SAFAInputMove.java
@@ -7,6 +7,7 @@
 package automata.safa;
 
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Set;
 
 import org.sat4j.specs.TimeoutException;
@@ -69,6 +70,11 @@ public class SAFAInputMove<P,S> {
 		}
 
 		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(to, from, guard.hashCode());
 	}
 
 	@Override

--- a/models/src/main/java/automata/sfa/SFAEpsilon.java
+++ b/models/src/main/java/automata/sfa/SFAEpsilon.java
@@ -8,6 +8,8 @@ package automata.sfa;
 
 import theory.BooleanAlgebra;
 
+import java.util.Objects;
+
 /**
  * Epsilon move of an SFA
  * @param <P> set of predicates over the domain S
@@ -46,6 +48,11 @@ public class SFAEpsilon<U,S> extends SFAMove<U,S> {
 		}
 
 		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(to, from);
 	}
 	
 	@Override

--- a/models/src/main/java/automata/sfa/SFAInputMove.java
+++ b/models/src/main/java/automata/sfa/SFAInputMove.java
@@ -10,6 +10,8 @@ import org.sat4j.specs.TimeoutException;
 
 import theory.BooleanAlgebra;
 
+import java.util.Objects;
+
 /**
  * SFAInputMove
  * @param <P> set of predicates over the domain S
@@ -63,6 +65,11 @@ public class SFAInputMove<P,S> extends SFAMove<P, S>{
 		}
 
 		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(to, from, guard.hashCode());
 	}
 
 	@Override


### PR DESCRIPTION
Pull request for issue #38. There are still a couple of types with non-default equals functions that do not implement corresponding hash functions. This may lead to some inconsistent behaviour when using hashes. However, I am not familiar enough with these object so I refrained from implementing some ad-hoc hash function.