### PR TITLE
Fixing Structural and Referntial equality Mistakes

### DIFF
--- a/models/src/main/java/automata/safa/SAFAInputMove.java
+++ b/models/src/main/java/automata/safa/SAFAInputMove.java
@@ -66,7 +66,7 @@ public class SAFAInputMove<P,S> {
 	public boolean equals(Object other) {
 		if (other instanceof SAFAInputMove<?, ?>) {
 			SAFAInputMove<?, ?> otherCasted = (SAFAInputMove<?, ?>) other;
-			return otherCasted.from==from && otherCasted.to.equals(to) && otherCasted.guard==guard;
+			return Objects.equals(otherCasted.from, from) && otherCasted.to.equals(to) && Objects.equals(otherCasted.guard,guard);
 		}
 
 		return false;

--- a/models/src/main/java/automata/sfa/SFAInputMove.java
+++ b/models/src/main/java/automata/sfa/SFAInputMove.java
@@ -61,7 +61,7 @@ public class SFAInputMove<P,S> extends SFAMove<P, S>{
 	public boolean equals(Object other) {
 		if (other instanceof SFAInputMove<?, ?>) {
 			SFAInputMove<?, ?> otherCasted = (SFAInputMove<?, ?>) other;
-			return otherCasted.from==from && otherCasted.to==to && otherCasted.guard==guard;
+			return Objects.equals(otherCasted.from, from) && Objects.equals(otherCasted.to, to) && Objects.equals(otherCasted.guard,guard);
 		}
 
 		return false;

--- a/models/src/main/java/utilities/IntegerPair.java
+++ b/models/src/main/java/utilities/IntegerPair.java
@@ -3,6 +3,8 @@
  */
 package utilities;
 
+import java.util.Objects;
+
 public class IntegerPair extends Pair<Integer,Integer> {
 	
 	private static final long serialVersionUID = -4974702686583519556L;
@@ -55,7 +57,7 @@ public class IntegerPair extends Pair<Integer,Integer> {
 		if (!(o instanceof Pair<?,?>))
 			return false;		
 		IntegerPair s = (IntegerPair) o;
-		return s.first==first && s.second==second;
+		return Objects.equals(s.first, first) && Objects.equals(s.second, second);
 	}
 	
 	public String toString(){

--- a/models/src/main/java/utilities/Pair.java
+++ b/models/src/main/java/utilities/Pair.java
@@ -1,6 +1,7 @@
 package utilities;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 
 public class Pair<A, B> implements Serializable{
@@ -31,10 +32,10 @@ public class Pair<A, B> implements Serializable{
     	if (other instanceof Pair) {
     		Pair<?, ?> otherPair = (Pair<?, ?>) other;
     		return 
-    		((  this.first == otherPair.first ||
+    		((  Objects.equals(this.first, otherPair.first) ||
     			( this.first != null && otherPair.first != null &&
     			  this.first.equals(otherPair.first))) &&
-    		 (	this.second == otherPair.second ||
+    		 (	Objects.equals(this.second, otherPair.second) ||
     			( this.second != null && otherPair.second != null &&
     			  this.second.equals(otherPair.second))) );
     	}


### PR DESCRIPTION
I found some inconsistent implementations of the equality method where referential equality (of guards) was used to show structural equality of moves. This is most likely not intentional and lead to a lot of unexpected behavior.

I fixed the instances where I could find these errors to occur. I am not sure if there are any more left. 

All tests pass.